### PR TITLE
Add termination on king capture

### DIFF
--- a/Chess.pcsp
+++ b/Chess.pcsp
@@ -285,7 +285,9 @@ ExecuteCapture(player, piece) = performCapture.player.piece{
 			}
 			
 			num_pieces--;
-			if (num_pieces < MIN_PIECES) {
+			if (piece == K) {
+				won = player;
+			} else if (num_pieces < MIN_PIECES) {
 				won = LESS_THAN_5;
 			}
 			piece_index = num_opp_pieces;


### PR DESCRIPTION
## Changes
This PR adds an additional condition to terminate the game on King captures (by our scoping, `endWin` does not include king captures).